### PR TITLE
Support Zabbix friendly output, suitable for piping directly to zabbix_sender

### DIFF
--- a/domain-check
+++ b/domain-check
@@ -285,7 +285,7 @@ check_domain_status()
     fi
 
     # Parse out the expiration date and registrar -- uses the last registrar it finds
-    REGISTRAR=`cat ${WHOIS_TMP} | ${AWK} -F: '/Registrar/ && $2 != ""  { REGISTRAR=substr($2,2,17) } END { print REGISTRAR }'`
+    REGISTRAR=`cat ${WHOIS_TMP} | ${AWK} -F: '/Registrar:/ && $2 != ""  { REGISTRAR=substr($2,2,17) } END { print REGISTRAR }'`
 
     if [ "${TLDTYPE}" == "uk" ]; # for .uk domain
     then
@@ -562,7 +562,26 @@ check_domain_status()
             tday=`echo ${tdomdate} | cut -d'/' -f3`
 	          DOMAINDATE=`echo $tday-$tmonth-$tyear`
     else # .com, .edu, .net and may work with others	 
-	    DOMAINDATE=`cat ${WHOIS_TMP} | ${AWK} '/Expiration/ { print $NF }'`	
+        tdomdate=`cat ${WHOIS_TMP} | ${AWK} '/Expiry Date:/ { print $NF }' | ${AWK} -F 'T' '{print $1}' | sed -e 's/-/\//g'`
+            tyear=`echo ${tdomdate} | ${CUT} -d'/' -f1`
+            tmon=`echo ${tdomdate} | ${CUT} -d'/' -f2`
+               case ${tmon} in
+                     1|01) tmonth=jan ;;
+                     2|02) tmonth=feb ;;
+                     3|03) tmonth=mar ;;
+                     4|04) tmonth=apr ;;
+                     5|05) tmonth=may ;;
+                     6|06) tmonth=jun ;;
+                     7|07) tmonth=jul ;;
+                     8|08) tmonth=aug ;;
+                     9|09) tmonth=sep ;;
+                     10) tmonth=oct ;;
+                     11) tmonth=nov ;;
+                     12) tmonth=dec ;;
+                      *) tmonth=0 ;;
+                esac
+            tday=`echo ${tdomdate} | ${CUT} -d'/' -f3`
+            DOMAINDATE=`echo $tday-$tmonth-$tyear`
     fi
 
     #echo $DOMAINDATE # debug 

--- a/domain-check
+++ b/domain-check
@@ -288,7 +288,7 @@ check_domain_status()
     fi
 
     # Parse out the expiration date and registrar -- uses the last registrar it finds
-    REGISTRAR=`cat ${WHOIS_TMP} | ${AWK} -F: '/Registrar:/ && $2 != ""  { REGISTRAR=substr($2,2,17) } END { print REGISTRAR }'`
+    REGISTRAR=`cat ${WHOIS_TMP} | ${AWK} -F: '/Registrar/ && $2 != ""  { REGISTRAR=substr($2,2,17) } END { print REGISTRAR }'`
 
     if [ "${TLDTYPE}" == "uk" ]; # for .uk domain
     then
@@ -565,26 +565,7 @@ check_domain_status()
             tday=`echo ${tdomdate} | cut -d'/' -f3`
 	          DOMAINDATE=`echo $tday-$tmonth-$tyear`
     else # .com, .edu, .net and may work with others	 
-        tdomdate=`cat ${WHOIS_TMP} | ${AWK} '/Expiry Date:/ { print $NF }' | ${AWK} -F 'T' '{print $1}' | sed -e 's/-/\//g'`
-            tyear=`echo ${tdomdate} | ${CUT} -d'/' -f1`
-            tmon=`echo ${tdomdate} | ${CUT} -d'/' -f2`
-               case ${tmon} in
-                     1|01) tmonth=jan ;;
-                     2|02) tmonth=feb ;;
-                     3|03) tmonth=mar ;;
-                     4|04) tmonth=apr ;;
-                     5|05) tmonth=may ;;
-                     6|06) tmonth=jun ;;
-                     7|07) tmonth=jul ;;
-                     8|08) tmonth=aug ;;
-                     9|09) tmonth=sep ;;
-                     10) tmonth=oct ;;
-                     11) tmonth=nov ;;
-                     12) tmonth=dec ;;
-                      *) tmonth=0 ;;
-                esac
-            tday=`echo ${tdomdate} | ${CUT} -d'/' -f3`
-            DOMAINDATE=`echo $tday-$tmonth-$tyear`
+	    DOMAINDATE=`cat ${WHOIS_TMP} | ${AWK} '/Expiration/ { print $NF }'`	
     fi
 
     #echo $DOMAINDATE # debug 

--- a/domain-check
+++ b/domain-check
@@ -288,7 +288,7 @@ check_domain_status()
     fi
 
     # Parse out the expiration date and registrar -- uses the last registrar it finds
-    REGISTRAR=`cat ${WHOIS_TMP} | ${AWK} -F: '/Registrar/ && $2 != ""  { REGISTRAR=substr($2,2,17) } END { print REGISTRAR }'`
+    REGISTRAR=`cat ${WHOIS_TMP} | ${AWK} -F: '/Registrar:/ && $2 != ""  { REGISTRAR=substr($2,2,17) } END { print REGISTRAR }'`
 
     if [ "${TLDTYPE}" == "uk" ]; # for .uk domain
     then
@@ -565,7 +565,26 @@ check_domain_status()
             tday=`echo ${tdomdate} | cut -d'/' -f3`
 	          DOMAINDATE=`echo $tday-$tmonth-$tyear`
     else # .com, .edu, .net and may work with others	 
-	    DOMAINDATE=`cat ${WHOIS_TMP} | ${AWK} '/Expiration/ { print $NF }'`	
+        tdomdate=`cat ${WHOIS_TMP} | ${AWK} '/Expiry Date:/ { print $NF }' | ${AWK} -F 'T' '{print $1}' | sed -e 's/-/\//g'`
+            tyear=`echo ${tdomdate} | ${CUT} -d'/' -f1`
+            tmon=`echo ${tdomdate} | ${CUT} -d'/' -f2`
+               case ${tmon} in
+                     1|01) tmonth=jan ;;
+                     2|02) tmonth=feb ;;
+                     3|03) tmonth=mar ;;
+                     4|04) tmonth=apr ;;
+                     5|05) tmonth=may ;;
+                     6|06) tmonth=jun ;;
+                     7|07) tmonth=jul ;;
+                     8|08) tmonth=aug ;;
+                     9|09) tmonth=sep ;;
+                     10) tmonth=oct ;;
+                     11) tmonth=nov ;;
+                     12) tmonth=dec ;;
+                      *) tmonth=0 ;;
+                esac
+            tday=`echo ${tdomdate} | ${CUT} -d'/' -f3`
+            DOMAINDATE=`echo $tday-$tmonth-$tyear`
     fi
 
     #echo $DOMAINDATE # debug 

--- a/domain-check
+++ b/domain-check
@@ -1,12 +1,15 @@
-#!/bin/bash 
+#!/usr/bin/env sh
 #
 # Program: Domain Expiration Check <domain-check>
 #
 # Author: Matty < matty91 at gmail dot com >
 # 
-# Current Version: 2.1
+# Current Version: 2.2
 #
 # Revision History:
+#  Version 2.2
+#   Added support for Zabbix-friendly output format -- Ian Gregory 
+#
 #  Version 2.1
 #   Added support for .fi and .io domain names -- Mihail Tchetchelnitski <mihail@mysteerio.fi>
 #
@@ -606,7 +609,7 @@ check_domain_status()
 ####################################################
 print_heading()
 {
-        if [ "${QUIET}" != "TRUE" ]
+        if [ "${QUIET}" != "TRUE" ] && [ "${ZABBIX}" != "TRUE" ]
         then
                 printf "\n%-35s %-17s %-8s %-11s %-5s\n" "Domain" "Registrar" "Status" "Expires" "Days Left"
                 echo "----------------------------------- ----------------- -------- ----------- ---------"
@@ -624,10 +627,15 @@ print_heading()
 #####################################################################
 prints()
 {
-    if [ "${QUIET}" != "TRUE" ]
+    if [ "${QUIET}" != "TRUE" ] && [ "${ZABBIX}" != "TRUE" ]
     then
             MIN_DATE=$(echo $3 | ${AWK} '{ print $1, $2, $4 }')
             printf "%-35s %-17s %-8s %-11s %-5s\n" "$1" "$5" "$2" "$MIN_DATE" "$4"
+    else
+        if [ "${QUIET}" != "TRUE" ] && [ "${ZABBIX}" == "TRUE" ]
+        then
+            printf "- domain.daysleft[%s] %s\n" "$1" "$4"
+        fi
     fi
 }
 
@@ -638,7 +646,7 @@ prints()
 ##########################################
 usage()
 {
-        echo "Usage: $0 [ -e email ] [ -x expir_days ] [ -q ] [ -a ] [ -h ]"
+        echo "Usage: $0 [ -e email ] [ -x expir_days ] [ -q ] [ -a ] [ -h ] [ -z ]"
         echo "          {[ -d domain_namee ]} || { -f domainfile}"
         echo ""
         echo "  -a               : Send a warning message through email "
@@ -649,11 +657,12 @@ usage()
         echo "  -s whois server  : Whois sever to query for information"
         echo "  -q               : Don't print anything on the console"
         echo "  -x days          : Domain expiration interval (eg. if domain_date < days)"
+        echo "  -z               : Print output suitable for zabbix_sender"
         echo ""
 }
 
 ### Evaluate the options passed on the command line
-while getopts ae:f:hd:s:qx: option
+while getopts ae:f:hd:s:qx:z option
 do
         case "${option}"
         in
@@ -664,6 +673,7 @@ do
                 s) WHOIS_SERVER=$OPTARG;;
                 q) QUIET="TRUE";;
                 x) WARNDAYS=$OPTARG;;
+                z) ZABBIX="TRUE";;
                 \?) usage
                     exit 1;;
         esac
@@ -717,7 +727,10 @@ else
 fi
 
 # Add an extra newline
-echo
+if [ "${QUIET}" != "TRUE" ] && [ "${ZABBIX}" != "TRUE" ]
+then
+    echo
+fi
 
 ### Remove the temporary files
 rm -f ${WHOIS_TMP}


### PR DESCRIPTION
Sample usage:

```
./domain-check -f /tmp/domains -z | zabbix_sender -sDomains -c /etc/zabbix/zabbix_agentd.conf -i -
```
